### PR TITLE
Add node status sensor

### DIFF
--- a/custom_components/zwave_mqtt/__init__.py
+++ b/custom_components/zwave_mqtt/__init__.py
@@ -16,6 +16,7 @@ from homeassistant.components import mqtt
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_START
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from . import const
 from .const import DATA_NODES, DATA_VALUES, DOMAIN, PLATFORMS, TOPIC_OPENZWAVE
@@ -65,6 +66,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         _LOGGER.info("NODE ADDED: %s - node id %s", node, node.id)
         hass.data[DOMAIN][DATA_NODES][node.id] = node
         hass.data[DOMAIN][DATA_VALUES][node.id] = []
+
+        # Create node statistics sensor
+        async_dispatcher_send(hass, "zwave_new_node_sensor", node)
 
     def node_changed(node):
         _LOGGER.info("node changed: %s", node)

--- a/custom_components/zwave_mqtt/const.py
+++ b/custom_components/zwave_mqtt/const.py
@@ -16,6 +16,13 @@ TOPIC_OPENZWAVE = "OpenZWave"
 # Entity Attributes
 ATTR_NODE_ID = "node_id"
 
+# Node Status Entity Attributes
+ATTR_QUERY_STAGE = "node_query_stage"
+ATTR_AWAKE = "is_awake"
+ATTR_READY = "is_ready"
+ATTR_FAILED = "is_failed"
+ATTR_ZWAVE_PLUS = "is_z_wave_plus"
+
 # Command Class IDs
 COMMAND_CLASS_ALARM = 113
 COMMAND_CLASS_ANTITHEFT = 93

--- a/custom_components/zwave_mqtt/sensor.py
+++ b/custom_components/zwave_mqtt/sensor.py
@@ -2,11 +2,17 @@
 
 import logging
 
+from openzwavemqtt.models.node import EVENT_NODE_CHANGED
+from openzwavemqtt.models.node_statistics import EVENT_NODE_STATISTICS_CHANGED
+
 from homeassistant.components.sensor import DEVICE_CLASS_BATTERY
 from homeassistant.const import TEMP_CELSIUS, TEMP_FAHRENHEIT
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity import Entity
 
+from . import const
+from .const import DOMAIN
 from .entity import ZWaveDeviceEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -36,7 +42,13 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
         async_add_entities([sensor])
 
+    @callback
+    def async_add_node_sensor(node):
+        sensor = ZWaveNodeStatisticsSensor(node)
+        async_add_entities([sensor])
+
     async_dispatcher_connect(hass, "zwave_new_sensor", async_add_sensor)
+    async_dispatcher_connect(hass, "zwave_new_node_sensor", async_add_node_sensor)
 
     return True
 
@@ -86,3 +98,94 @@ class ZWaveBatterySensor(ZWaveSensor):
     def device_class(self):
         """Return the device class of the sensor."""
         return DEVICE_CLASS_BATTERY
+
+
+class ZWaveNodeStatisticsSensor(Entity):
+    """Representation of a Z-Wave node status sensor."""
+
+    def __init__(self, node):
+        """Initilize a generic Z-Wave device entity."""
+        self.node = node
+        self.options = node.options
+        self.attributes = {}
+        self.statistics = {}
+
+    @callback
+    def stats_changed(self, stats):
+        """Call when the statistics are changed."""
+        self.statistics = stats
+        stat_attributes = [
+            "average_request_rtt",
+            "average_response_rtt",
+            "received_packets",
+            "received_unsolicited",
+            "received_dup_packets",
+            "send_count",
+            "sent_failed",
+            "tx_time",
+        ]
+
+        for attr in stat_attributes:
+            value = getattr(self.statistics, attr)
+            if value:
+                self.attributes[attr] = value
+
+        self.async_schedule_update_ha_state()
+
+    @callback
+    def node_changed(self, node):
+        """Call when the node is changed."""
+        self.node = node
+        node_attributes = [
+            const.ATTR_AWAKE,
+            const.ATTR_FAILED,
+            const.ATTR_NODE_ID,
+            const.ATTR_QUERY_STAGE,
+            const.ATTR_ZWAVE_PLUS,
+            "is_beaming",
+            "is_routing",
+        ]
+
+        for attr in node_attributes:
+            value = getattr(self.node, attr)
+            self.attributes[attr] = value
+
+        self.async_schedule_update_ha_state()
+
+    async def async_added_to_hass(self):
+        """Call when entity is added."""
+        self.options.listen(EVENT_NODE_STATISTICS_CHANGED, self.stats_changed)
+        self.options.listen(EVENT_NODE_CHANGED, self.node_changed)
+        self.node_changed(self.node)
+        self.stats_changed(self.node.get_statistics())
+
+    @property
+    def device_info(self):
+        """Return device information for the device registry."""
+        return {
+            "identifiers": {(DOMAIN, self.node.node_id)},
+            "name": f"{self.node.node_manufacturer_name} {self.node.node_product_name}",
+            "manufacturer": self.node.node_manufacturer_name,
+            "model": self.node.node_product_name,
+        }
+
+    @property
+    def device_state_attributes(self):
+        """Return the device specific state attributes."""
+        self.attributes[const.ATTR_NODE_ID] = self.node.node_id
+        return self.attributes
+
+    @property
+    def name(self):
+        """Return the name of the entity."""
+        return f"{self.node.node_manufacturer_name} {self.node.node_product_name}: Node Status"
+
+    @property
+    def state(self):
+        """Return the state of the entity."""
+        return self.node.node_query_stage
+
+    @property
+    def unique_id(self):
+        """Return the unique_id of the entity."""
+        return f"node-{self.node.id}"


### PR DESCRIPTION
Fixes #5 

Adds a node status sensor. This is the replacement for the `zwave.xyz` entities in the existing 1.4 component.