### PR TITLE
Enable debug logging in tests

### DIFF
--- a/custom_components/zwave_mqtt/__init__.py
+++ b/custom_components/zwave_mqtt/__init__.py
@@ -79,7 +79,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     @callback
     def async_node_changed(node):
-        _LOGGER.info("node changed: %s", node)
+        _LOGGER.info("NODE CHANGED: %s", node)
         data_nodes[node.id] = node
 
     @callback
@@ -93,7 +93,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             "COMMAND_CLASS_VERSION",
         ]:
             _LOGGER.debug(
-                "Value added: node %s - value label %s - value %s -- id %s -- cc %s",
+                "VALUE ADDED: node %s - value label %s - value %s -- id %s -- cc %s",
                 value.node.id,
                 value.label,
                 value.value,
@@ -125,7 +125,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     @callback
     def async_value_changed(value):
         _LOGGER.debug(
-            "value changed - node %s - value label %s - value %s",
+            "VALUE CHANGED: node %s - value label %s - value %s",
             value.node,
             value.label,
             value.value,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Helpers for tests."""
 import json
+import logging
 from pathlib import Path
 
 from asynctest import patch
@@ -8,6 +9,8 @@ import pytest
 from homeassistant import config_entries, core
 
 from tests.common import mock_storage
+
+logging.basicConfig(level=logging.DEBUG)
 
 
 @pytest.fixture


### PR DESCRIPTION
This enables debug logging in the tests so you can see what is going on.

HOWEVER, the discovery logging is extremely verbose. Every single check has a log statement. We also log on every value and node that is added. So just loading the `generic_network_dump` floods the logs.