### PR TITLE
Add cover support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This integration allows you to utilize OpenZWave's qt-openzwave to control a Z-W
 
 
 ## Features and Limitations
-- Currently already supports binary_sensor, fan, sensor, and switch platforms
+- Currently already supports binary_sensor, cover, fan, sensor, and switch platforms
 - Scenes support for both Central scenes and node/network scenes:
     Will fire HomeAssistant event zwave_mqtt.scene_activated.
 - Light support is currently limited to dimmers only, RGB bulbs are not yet implemented.

--- a/custom_components/zwave_mqtt/const.py
+++ b/custom_components/zwave_mqtt/const.py
@@ -1,7 +1,7 @@
 """Constants for the zwave_mqtt integration."""
 
 DOMAIN = "zwave_mqtt"
-PLATFORMS = ["binary_sensor", "fan", "sensor", "switch", "light"]
+PLATFORMS = ["binary_sensor", "cover", "fan", "sensor", "switch", "light"]
 
 # MQTT Topics
 TOPIC_OPENZWAVE = "OpenZWave"
@@ -185,3 +185,10 @@ DISC_SCHEMAS = "schemas"
 DISC_SPECIFIC_DEVICE_CLASS = "specific_device_class"
 DISC_TYPE = "type"
 DISC_VALUES = "values"
+
+
+# Manufacturer IDs
+MANUFACTURER_ID_FIBARO = "0x010f"
+
+# Product Types
+PRODUCT_TYPE_FIBARO_FGRM222 = "0x0302"

--- a/custom_components/zwave_mqtt/cover.py
+++ b/custom_components/zwave_mqtt/cover.py
@@ -1,0 +1,136 @@
+"""Support for Z-Wave cover."""
+import logging
+
+from openzwavemqtt.const import CommandClass
+
+from homeassistant.components.cover import (
+    ATTR_POSITION,
+    ATTR_TILT_POSITION,
+    SUPPORT_CLOSE,
+    SUPPORT_CLOSE_TILT,
+    SUPPORT_OPEN,
+    SUPPORT_OPEN_TILT,
+    SUPPORT_SET_POSITION,
+    SUPPORT_SET_TILT_POSITION,
+    CoverDevice,
+)
+from homeassistant.core import callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+
+from .const import DOMAIN, MANUFACTURER_ID_FIBARO, PRODUCT_TYPE_FIBARO_FGRM222
+from .entity import ZWaveDeviceEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+SUPPORTED_FEATURES_POSITION = SUPPORT_OPEN | SUPPORT_CLOSE | SUPPORT_SET_POSITION
+SUPPORTED_FEATURES_TILT = (
+    SUPPORT_OPEN_TILT | SUPPORT_CLOSE_TILT | SUPPORT_SET_TILT_POSITION
+)
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up Z-Wave Cover from Config Entry."""
+
+    @callback
+    def async_add_cover(values):
+        """Add Z-Wave Cover."""
+        # Specific Cover Types
+        if values.primary.command_class == CommandClass.SWITCH_MULTILEVEL:
+            if (
+                values.primary.node.node_manufacturer_id == MANUFACTURER_ID_FIBARO
+                and values.primary.node.node_product_type == PRODUCT_TYPE_FIBARO_FGRM222
+            ):
+                cover = FibaroFGRM222Cover(values)
+            else:
+                cover = ZWaveCover(values)
+
+        else:
+            _LOGGER.warning("Cover not implemented for values %s", values.primary)
+            return
+
+        async_add_entities([cover])
+
+    async_dispatcher_connect(hass, "zwave_new_cover", async_add_cover)
+
+    await hass.data[DOMAIN][config_entry.entry_id]["mark_platform_loaded"]("cover")
+
+
+class ZWaveCover(ZWaveDeviceEntity, CoverDevice):
+    """Representation of a Z-Wave cover."""
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        return SUPPORTED_FEATURES_POSITION
+
+    @property
+    def is_closed(self):
+        """Return true if cover is closed."""
+        return self.values.primary.value < 5
+
+    @property
+    def current_cover_position(self):
+        """Return the current position of cover where 0 means closed and 100 is fully open."""
+        return self.values.primary.value
+
+    async def async_set_cover_position(self, **kwargs):
+        """Move the cover to a specific position."""
+        self.values.primary.send_value(kwargs[ATTR_POSITION])
+
+    async def async_open_cover(self, **kwargs):
+        """Open the cover."""
+        self.values.primary.send_value(99)
+
+    async def async_close_cover(self, **kwargs):
+        """Close cover."""
+        self.values.primary.send_value(0)
+
+
+class FibaroFGRM222Cover(ZWaveDeviceEntity, CoverDevice):
+    """Representation of a Fibaro FGRM-222 cover."""
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        return SUPPORTED_FEATURES_POSITION | SUPPORTED_FEATURES_TILT
+
+    @property
+    def is_closed(self):
+        """Return true if cover is closed."""
+        return self.values.fgrm222_slat_position.value < 5
+
+    @property
+    def current_cover_position(self):
+        """Return the current position of cover where 0 means closed and 100 is fully open."""
+        return self.values.fgrm222_slat_position.value
+
+    @property
+    def current_cover_tilt_position(self):
+        """Return the current tilt position of the cover where 0 means closed/no tilt and 100 means open/maximum tilt."""
+        return self.values.fgrm222_tilt_position.value
+
+    async def async_open_cover(self, **kwargs):
+        """Open the cover."""
+        self.values.fgrm222_slat_position.send_value(99)
+        self.values.fgrm222_tilt_position.send_value(99)
+
+    async def async_close_cover(self, **kwargs):
+        """Close cover."""
+        self.values.fgrm222_slat_position.send_value(0)
+        self.values.fgrm222_tilt_position.send_value(0)
+
+    async def async_set_cover_position(self, **kwargs):
+        """Move the cover to a specific position."""
+        self.values.fgrm222_slat_position.send_value(kwargs[ATTR_POSITION])
+
+    async def async_set_cover_tilt_position(self, **kwargs):
+        """Move the cover tilt to a specific position."""
+        self.values.fgrm222_tilt_position.send_value(kwargs[ATTR_TILT_POSITION])
+
+    async def async_open_cover_tilt(self, **kwargs):
+        """Open the cover tilt."""
+        self.values.fgrm222_tilt_position.send_value(99)
+
+    async def async_close_cover_tilt(self, **kwargs):
+        """Close the cover tilt."""
+        self.values.fgrm222_tilt_position.send_value(0)

--- a/custom_components/zwave_mqtt/cover.py
+++ b/custom_components/zwave_mqtt/cover.py
@@ -35,18 +35,17 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     def async_add_cover(values):
         """Add Z-Wave Cover."""
         # Specific Cover Types
-        if values.primary.command_class == CommandClass.SWITCH_MULTILEVEL:
-            if (
-                values.primary.node.node_manufacturer_id == MANUFACTURER_ID_FIBARO
-                and values.primary.node.node_product_type == PRODUCT_TYPE_FIBARO_FGRM222
-            ):
-                cover = FibaroFGRM222Cover(values)
-            else:
-                cover = ZWaveCover(values)
-
-        else:
+        if values.primary.command_class != CommandClass.SWITCH_MULTILEVEL:
             _LOGGER.warning("Cover not implemented for values %s", values.primary)
             return
+
+        if (
+            values.primary.node.node_manufacturer_id == MANUFACTURER_ID_FIBARO
+            and values.primary.node.node_product_type == PRODUCT_TYPE_FIBARO_FGRM222
+        ):
+            cover = FibaroFGRM222Cover(values)
+        else:
+            cover = ZWaveCover(values)
 
         async_add_entities([cover])
 

--- a/custom_components/zwave_mqtt/discovery.py
+++ b/custom_components/zwave_mqtt/discovery.py
@@ -114,6 +114,7 @@ DISCOVERY_SCHEMAS = [
             **{
                 const.DISC_PRIMARY: {
                     const.DISC_COMMAND_CLASS: [CommandClass.SWITCH_MULTILEVEL],
+                    const.DISC_INDEX: [ValueIndex.SWITCH_MULTILEVEL_LEVEL],
                     const.DISC_GENRE: ValueGenre.USER,
                 },
                 "open": {
@@ -124,6 +125,16 @@ DISCOVERY_SCHEMAS = [
                 "close": {
                     const.DISC_COMMAND_CLASS: [CommandClass.SWITCH_MULTILEVEL],
                     const.DISC_INDEX: [ValueIndex.SWITCH_MULTILEVEL_DIM],
+                    const.DISC_OPTIONAL: True,
+                },
+                "fgrm222_slat_position": {
+                    const.DISC_COMMAND_CLASS: [CommandClass.MANUFACTURER_PROPRIETARY],
+                    const.DISC_INDEX: [0],
+                    const.DISC_OPTIONAL: True,
+                },
+                "fgrm222_tilt_position": {
+                    const.DISC_COMMAND_CLASS: [CommandClass.MANUFACTURER_PROPRIETARY],
+                    const.DISC_INDEX: [1],
                     const.DISC_OPTIONAL: True,
                 },
             },


### PR DESCRIPTION
Hello,

this implementation includes a generic cover class and a specific class for the Fibaro FGRM-222 device to support the "Venetian blind"/tilt mode.

Currently, the decision whether to use the FibaroFGRM222Cover class or not is solely based on the MANUFACTURER_ID and PRODUCT_TYPE.
In the future, the decision should also be made based on the configuration (Venetian blind mode active), once the python-openzwave-mqtt library properly supports list values (see cgarwood/python-openzwave-mqtt#53).

A few limitations of this implementation currently:
- Only covers with primary CommandClass `SWITCH_MULTILEVEL` supported
- `SUPPORT_STOP` and `SUPPORT_STOP_TILT` not available - the implementation via the open/close switches (like in the old Z-Wave component) did not work in my tests, so I used the level value instead. Maybe someone else could implement/test this.
- Fibaro FGRM-222 covers will always have tilt support regardless of the configuration

Fixes #9 