### PR TITLE
Prefer target level for light state

### DIFF
--- a/custom_components/zwave_mqtt/light.py
+++ b/custom_components/zwave_mqtt/light.py
@@ -67,6 +67,8 @@ class ZwaveDimmer(ZWaveDeviceEntity, Light):
     @property
     def is_on(self):
         """Return true if device is on (brightness above 0)."""
+        if "target" in self.values:
+            return self.values.target.value > 0
         return self.values.primary.value > 0
 
     @property


### PR DESCRIPTION
newer z-wave dimmers/bulbs will set the target property if they're transitioning to a new state.
Partly related to https://github.com/cgarwood/homeassistant-zwave_mqtt/issues/72

minor fix