### PR TITLE
Add sensor for Basic CommandClass

### DIFF
--- a/custom_components/zwave_mqtt/discovery.py
+++ b/custom_components/zwave_mqtt/discovery.py
@@ -299,6 +299,19 @@ DISCOVERY_SCHEMAS = [
         ),
     },
     {
+        const.DISC_COMPONENT: "sensor",
+        const.DISC_VALUES: dict(
+            DEFAULT_VALUES_SCHEMA,
+            **{
+                const.DISC_PRIMARY: {
+                    const.DISC_COMMAND_CLASS: [
+                        CommandClass.BASIC,
+                    ],
+                }
+            },
+        ),
+    },
+    {
         const.DISC_COMPONENT: "switch",
         const.DISC_GENERIC_DEVICE_CLASS: [
             const.GENERIC_TYPE_METER,

--- a/custom_components/zwave_mqtt/discovery.py
+++ b/custom_components/zwave_mqtt/discovery.py
@@ -302,13 +302,7 @@ DISCOVERY_SCHEMAS = [
         const.DISC_COMPONENT: "sensor",
         const.DISC_VALUES: dict(
             DEFAULT_VALUES_SCHEMA,
-            **{
-                const.DISC_PRIMARY: {
-                    const.DISC_COMMAND_CLASS: [
-                        CommandClass.BASIC,
-                    ],
-                }
-            },
+            **{const.DISC_PRIMARY: {const.DISC_COMMAND_CLASS: [CommandClass.BASIC]}},
         ),
     },
     {


### PR DESCRIPTION
Adds an additional sensor for devices supporting/needing the Basic CommandClass.

Fix for https://github.com/cgarwood/homeassistant-zwave_mqtt/issues/82
Related to https://github.com/OpenZWave/qt-openzwave/issues/60