### PR TITLE
Handle restarts and removals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 bin
 lib
 .DS_Store
+.vscode/settings.json

--- a/custom_components/zwave_mqtt/__init__.py
+++ b/custom_components/zwave_mqtt/__init__.py
@@ -135,12 +135,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         node_data_values = data_values[node_id]
 
         # Check if this value should be tracked by an existing entity
-        # This may happen during restarts of the daemon.
         value_unique_id = f"{value.node.id}-{value.value_id_key}"
         for values in node_data_values:
+            values.check_value(value)
             if values.unique_id == value_unique_id:
-                values.check_value(value)
-                return
+                return  # this value already has an entity
 
         # Run discovery on it and see if any entities need created
         for schema in DISCOVERY_SCHEMAS:

--- a/custom_components/zwave_mqtt/__init__.py
+++ b/custom_components/zwave_mqtt/__init__.py
@@ -99,7 +99,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         # cleanup device/entity registry if we know this node is permanently deleted
         # entities itself are removed by the values logic
         if node.id in removed_nodes:
-            hass.async_add_job(handle_remove_node(hass, node.id))
+            hass.async_create_task(handle_remove_node(hass, node.id))
 
     def async_instance_event(message):
         event = message["event"]

--- a/custom_components/zwave_mqtt/const.py
+++ b/custom_components/zwave_mqtt/const.py
@@ -26,7 +26,7 @@ SERVICE_REPLACE_FAILED_NODE = "replace_failed_node"
 SERVICE_CANCEL_COMMAND = "cancel_command"
 SERVICE_SET_CONFIG_PARAMETER = "set_config_parameter"
 
-# Events
+# Home Assistant Events
 EVENT_SCENE_ACTIVATED = f"{DOMAIN}.scene_activated"
 
 # Signals

--- a/custom_components/zwave_mqtt/const.py
+++ b/custom_components/zwave_mqtt/const.py
@@ -29,6 +29,9 @@ SERVICE_SET_CONFIG_PARAMETER = "set_config_parameter"
 # Events
 EVENT_SCENE_ACTIVATED = f"{DOMAIN}.scene_activated"
 
+# Signals
+SIGNAL_DELETE_ENTITY = f"{DOMAIN}_delete_entity"
+
 # Discovery Information
 GENERIC_TYPE_WHATEVER = None  # Match ALL
 SPECIFIC_TYPE_WHATEVER = None  # Match ALL

--- a/custom_components/zwave_mqtt/entity.py
+++ b/custom_components/zwave_mqtt/entity.py
@@ -142,7 +142,6 @@ class ZWaveDeviceEntity(Entity):
         self.values = values
         self.options = values._options
         self.values._entity = self
-        self._dispatcher_callbacks = []
 
     @callback
     def value_changed(self, value):

--- a/custom_components/zwave_mqtt/entity.py
+++ b/custom_components/zwave_mqtt/entity.py
@@ -148,7 +148,7 @@ class ZWaveDeviceEntity(Entity):
     def value_changed(self, value):
         """Call when the value is changed."""
         if value.value_id_key in (v.value_id_key for v in self.values if v):
-            self.async_schedule_update_ha_state()
+            self.async_write_ha_state()
 
     @callback
     def value_added(self):
@@ -157,7 +157,7 @@ class ZWaveDeviceEntity(Entity):
     @callback
     def instance_updated(self, new_status):
         """Call when the instance status changes."""
-        self.async_schedule_update_ha_state()
+        self.async_write_ha_state()
 
     async def async_added_to_hass(self):
         """Call when entity is added."""

--- a/custom_components/zwave_mqtt/entity.py
+++ b/custom_components/zwave_mqtt/entity.py
@@ -25,7 +25,7 @@ class ZWaveDeviceEntityValues:
     def __init__(self, hass, options, schema, primary_value):
         """Initialize the values object with the passed entity schema."""
         self._hass = hass
-        self.entity_created = False
+        self._entity_created = False
         self._schema = copy.deepcopy(schema)
         self._values = {}
         self._options = options
@@ -86,7 +86,7 @@ class ZWaveDeviceEntityValues:
             self._values[name] = value
 
             # If the entity has already been created, notify it of the new value.
-            if self.entity_created:
+            if self._entity_created:
                 async_dispatcher_send(self._hass, f"{self.unique_id}_value_added")
                 self._entity.value_added()
 
@@ -97,7 +97,7 @@ class ZWaveDeviceEntityValues:
     def _check_entity_ready(self):
         """Check if all required values are discovered and create entity."""
         # Abort if the entity has already been created
-        if self.entity_created:
+        if self._entity_created:
             return
 
         # Go through values defined in the schema and abort if a required value is missing.
@@ -124,7 +124,7 @@ class ZWaveDeviceEntityValues:
             self.primary.genre,
             component,
         )
-        self.entity_created = True
+        self._entity_created = True
 
         if component in PLATFORMS:
             async_dispatcher_send(self._hass, f"zwave_new_{component}", self)

--- a/custom_components/zwave_mqtt/entity.py
+++ b/custom_components/zwave_mqtt/entity.py
@@ -165,7 +165,6 @@ class ZWaveDeviceEntity(Entity):
         self.options.listen(EVENT_VALUE_CHANGED, self.value_changed)
         self.options.listen(EVENT_INSTANCE_STATUS_CHANGED, self.instance_updated)
         # add to on_remove so they will be cleaned up on entity removal
-        self.async_on_remove(self._onremove_callback)
         self.async_on_remove(
             async_dispatcher_connect(
                 self.hass, const.SIGNAL_DELETE_ENTITY, self._delete_callback
@@ -229,7 +228,7 @@ class ZWaveDeviceEntity(Entity):
         if values_unique_id == self.unique_id:
             await self.async_remove()
 
-    async def _onremove_callback(self) -> None:
+    async def async_will_remove_from_hass(self) -> None:
         """Call when entity will be removed from hass."""
         # cleanup OZW listeners
         self.options.listeners[EVENT_VALUE_CHANGED].remove(self.value_changed)

--- a/custom_components/zwave_mqtt/entity.py
+++ b/custom_components/zwave_mqtt/entity.py
@@ -25,7 +25,7 @@ class ZWaveDeviceEntityValues:
     def __init__(self, hass, options, schema, primary_value):
         """Initialize the values object with the passed entity schema."""
         self._hass = hass
-        self.entity_created = False
+        self._entity_created = False
         self._schema = copy.deepcopy(schema)
         self._values = {}
         self._options = options
@@ -86,9 +86,8 @@ class ZWaveDeviceEntityValues:
             self._values[name] = value
 
             # If the entity has already been created, notify it of the new value.
-            if self.entity_created:
+            if self._entity_created:
                 async_dispatcher_send(self._hass, f"{self.unique_id}_value_added")
-                self._entity.value_added()
 
             # Check if entity has all required values and create the entity if needed.
             self._check_entity_ready()
@@ -97,7 +96,7 @@ class ZWaveDeviceEntityValues:
     def _check_entity_ready(self):
         """Check if all required values are discovered and create entity."""
         # Abort if the entity has already been created
-        if self.entity_created:
+        if self._entity_created:
             return
 
         # Go through values defined in the schema and abort if a required value is missing.
@@ -124,7 +123,7 @@ class ZWaveDeviceEntityValues:
             self.primary.genre,
             component,
         )
-        self.entity_created = True
+        self._entity_created = True
 
         if component in PLATFORMS:
             async_dispatcher_send(self._hass, f"zwave_new_{component}", self)


### PR DESCRIPTION
The announced PR that will make thing a bit more robust, especially to handle OZW being offline/restarting and such. The integration will now be able to survive that.

Also fixes the usecase where a Z-Wave node actually get removed from the mesh and entities/devices need to be cleanup up in hass.