### PR TITLE
Use the node name if it's avalible to name devices

### DIFF
--- a/custom_components/zwave_mqtt/entity.py
+++ b/custom_components/zwave_mqtt/entity.py
@@ -263,7 +263,9 @@ class ZWaveDeviceEntity(Entity):
 
 def create_device_name(node: OZWNode):
     """Generate sensible (short) default device name from a OZWNode."""
-    if node.meta_data["Name"]:
+    if node.node_name:
+        dev_name = node.node_name
+    elif node.meta_data["Name"]:
         dev_name = node.meta_data["Name"]
     elif node.node_product_name:
         dev_name = node.node_product_name


### PR DESCRIPTION
Prefer the open-zwave node name to name the device if it is available. If the device has been named with ozw-admin this name will be used first. This allows for easier naming and management of your z-wave network independent of Home Assistant.